### PR TITLE
[ftr] Support runtime backendURL via config.json (#16)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "resources/web-components/edirom-keycloak-handler"]
+	path = resources/web-components/edirom-keycloak-handler
+	url = https://github.com/Edirom/edirom-keycloak-handler.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "resources/web-components/edirom-keycloak-handler"]
-	path = resources/web-components/edirom-keycloak-handler
-	url = https://github.com/Edirom/edirom-keycloak-handler.git

--- a/app/Application.js
+++ b/app/Application.js
@@ -97,11 +97,13 @@ Ext.define('EdiromOnline.Application', {
                     // If there is only one edition in the backend load it directly
                     }else if(!Array.isArray(editions)) {
                         this.activeEdition = editions.id;
+                        this.loadWebComponents();
                         this.loadEdiromForEdition();
 
                     // If there is only one edition in the backend load it directly
                     }else if(editions.length == 1) {
                         this.activeEdition = editions[0].id;
+                        this.loadWebComponents();
                         this.loadEdiromForEdition();
 
                     // If there are multiple editions in the backend show a selection screen
@@ -133,6 +135,7 @@ Ext.define('EdiromOnline.Application', {
                         
                         html += '</ul></div>';
                         document.body.innerHTML = html;
+                        this.loadWebComponents();
                     }                 
 
                 }, this),
@@ -141,6 +144,7 @@ Ext.define('EdiromOnline.Application', {
 
         }else {
             me.activeEdition = editionParam;
+            me.loadWebComponents();
             me.loadEdiromForEdition();
         }
     },
@@ -268,6 +272,32 @@ Ext.define('EdiromOnline.Application', {
         var uris = me.getController('PreferenceController').getPreference('start_documents_uri', true);
         if(uris){
             window.loadLink(uris);
+        }
+    },
+    loadWebComponents: function() {
+        var me = this;
+        var components = me.getController('PreferenceController').getPreference('web-components', true);
+        
+        if(components){
+            if (components['edirom_keycloak_handler']) {
+                // Dynamically load the keycloak handler script
+                var handlerScript = document.createElement('script');
+                handlerScript.src = components['edirom_keycloak_handler'].script || 'resources/web-components/edirom-keycloak-handler/keycloak-handler.js';
+                document.body.appendChild(handlerScript);
+
+                // Create the keycloak handler element
+                var handlerElement = document.createElement('keycloak-handler');
+                document.body.appendChild(handlerElement);
+
+                // Set attributes for the keycloak handler element
+                handlerElement.setAttribute('url', components['edirom_keycloak_handler']['url']);
+                handlerElement.setAttribute('realm', components['edirom_keycloak_handler']['realm']);
+                handlerElement.setAttribute('client-id', components['edirom_keycloak_handler']['client_id']);
+                handlerElement.setAttribute(
+                    'redirect_uri',
+                    window.location.origin + (components['edirom_keycloak_handler']['redirect_uri'] || window.location.origin + '/silent-check-sso.html')
+                );
+            }
         }
     }
 });

--- a/app/Application.js
+++ b/app/Application.js
@@ -23,6 +23,7 @@ Ext.define('EdiromOnline.Application', {
     
     controllers: [
         'AJAXController',
+        'ConfigController',
         'CookieController',
         'LanguageController',
         'PreferenceController',
@@ -68,7 +69,16 @@ Ext.define('EdiromOnline.Application', {
 
     launch: function() {
         var me = this;
-        
+
+        me.getController('ConfigController').loadConfig(function (config) {
+            me.backendURL = config.backendURL || me.backendURL;
+            me.initializeApplication();
+        }, me);
+    },
+
+    initializeApplication: function () {
+        var me = this;
+
         window.getActiveEdition = Ext.bind(this.getActiveEdition, this);
 
         me.addEvents('workSelected');
@@ -97,14 +107,16 @@ Ext.define('EdiromOnline.Application', {
                     // If there is only one edition in the backend load it directly
                     }else if(!Array.isArray(editions)) {
                         this.activeEdition = editions.id;
-                        this.loadWebComponents();
-                        this.loadEdiromForEdition();
+                        me.getController('PreferenceController').initPreferences(me.activeEdition);
+                        me.loadWebComponents();
+                        me.loadEdiromForEdition();
 
                     // If there is only one edition in the backend load it directly
                     }else if(editions.length == 1) {
                         this.activeEdition = editions[0].id;
-                        this.loadWebComponents();
-                        this.loadEdiromForEdition();
+                        me.getController('PreferenceController').initPreferences(me.activeEdition);
+                        me.loadWebComponents();
+                        me.loadEdiromForEdition();
 
                     // If there are multiple editions in the backend show a selection screen
                     }else {
@@ -135,7 +147,6 @@ Ext.define('EdiromOnline.Application', {
                         
                         html += '</ul></div>';
                         document.body.innerHTML = html;
-                        this.loadWebComponents();
                     }                 
 
                 }, this),
@@ -144,6 +155,7 @@ Ext.define('EdiromOnline.Application', {
 
         }else {
             me.activeEdition = editionParam;
+            me.getController('PreferenceController').initPreferences(me.activeEdition);
             me.loadWebComponents();
             me.loadEdiromForEdition();
         }
@@ -181,8 +193,7 @@ Ext.define('EdiromOnline.Application', {
             2, // retries
             false // async
         );
-        
-        me.getController('PreferenceController').initPreferences(me.activeEdition);
+
         me.getController('LanguageController').initLangFile(me.activeEdition, 'de');
         me.getController('LanguageController').initLangFile(me.activeEdition, 'en');
         me.initDataStores();
@@ -276,28 +287,42 @@ Ext.define('EdiromOnline.Application', {
     },
     loadWebComponents: function() {
         var me = this;
-        var components = me.getController('PreferenceController').getPreference('web-components', true);
-        
-        if(components){
-            if (components['edirom_keycloak_handler']) {
-                // Dynamically load the keycloak handler script
-                var handlerScript = document.createElement('script');
-                handlerScript.src = components['edirom_keycloak_handler'].script || 'resources/web-components/edirom-keycloak-handler/keycloak-handler.js';
-                document.body.appendChild(handlerScript);
 
-                // Create the keycloak handler element
-                var handlerElement = document.createElement('keycloak-handler');
-                document.body.appendChild(handlerElement);
+        var prefController = me.getController('PreferenceController');
+        if (!prefController) {
+            console.warn('PreferenceController not available');
+            return;
+        }
 
-                // Set attributes for the keycloak handler element
-                handlerElement.setAttribute('url', components['edirom_keycloak_handler']['url']);
-                handlerElement.setAttribute('realm', components['edirom_keycloak_handler']['realm']);
-                handlerElement.setAttribute('client-id', components['edirom_keycloak_handler']['client_id']);
-                handlerElement.setAttribute(
-                    'redirect_uri',
-                    window.location.origin + (components['edirom_keycloak_handler']['redirect_uri'] || window.location.origin + '/silent-check-sso.html')
-                );
+        try {
+            var components = prefController.getPreference('web-components', true);
+
+            if (components !== null && components !== undefined) {
+                if (components['edirom_keycloak_handler']) {
+                    // Dynamically load the keycloak handler script
+                    var handlerScript = document.createElement('script');
+                    handlerScript.src = components['edirom_keycloak_handler'].script || 'resources/web-components/edirom-keycloak-handler/keycloak-handler.js';
+                    document.body.appendChild(handlerScript);
+
+                    // Create the keycloak handler element
+                    var handlerElement = document.createElement('keycloak-handler');
+                    document.body.appendChild(handlerElement);
+
+                    // Set attributes for the keycloak handler element
+                    handlerElement.setAttribute('url', components['edirom_keycloak_handler']['url']);
+                    handlerElement.setAttribute('realm', components['edirom_keycloak_handler']['realm']);
+                    handlerElement.setAttribute('client-id', components['edirom_keycloak_handler']['client_id']);
+                    handlerElement.setAttribute(
+                        'redirect_uri',
+                        window.location.origin + (components['edirom_keycloak_handler']['redirect_uri'] || window.location.origin + '/silent-check-sso.html')
+                    );
+                }
+            } else {
+                console.log('No web-components configuration found in preferences');
             }
+        }
+        catch (error) {
+            console.warn('Error loading web-components preference:', error);
         }
     }
 });

--- a/app/Application.js
+++ b/app/Application.js
@@ -284,45 +284,5 @@ Ext.define('EdiromOnline.Application', {
         if(uris){
             window.loadLink(uris);
         }
-    },
-    loadWebComponents: function() {
-        var me = this;
-
-        var prefController = me.getController('PreferenceController');
-        if (!prefController) {
-            console.warn('PreferenceController not available');
-            return;
-        }
-
-        try {
-            var components = prefController.getPreference('web-components', true);
-
-            if (components !== null && components !== undefined) {
-                if (components['edirom_keycloak_handler']) {
-                    // Dynamically load the keycloak handler script
-                    var handlerScript = document.createElement('script');
-                    handlerScript.src = components['edirom_keycloak_handler'].script || 'resources/web-components/edirom-keycloak-handler/keycloak-handler.js';
-                    document.body.appendChild(handlerScript);
-
-                    // Create the keycloak handler element
-                    var handlerElement = document.createElement('keycloak-handler');
-                    document.body.appendChild(handlerElement);
-
-                    // Set attributes for the keycloak handler element
-                    handlerElement.setAttribute('url', components['edirom_keycloak_handler']['url']);
-                    handlerElement.setAttribute('realm', components['edirom_keycloak_handler']['realm']);
-                    handlerElement.setAttribute('client-id', components['edirom_keycloak_handler']['client_id']);
-                    handlerElement.setAttribute(
-                        'redirect_uri',
-                        window.location.origin + (components['edirom_keycloak_handler']['redirect_uri'] || window.location.origin + '/silent-check-sso.html')
-                    );
-                }
-            } else {
-                console.log('No web-components configuration found in preferences');
-            }
-        }
-        catch (error) {
-            console.warn('Error loading web-components preference:', error);
-        }
     }
 });

--- a/app/controller/ConfigController.js
+++ b/app/controller/ConfigController.js
@@ -4,7 +4,6 @@ Ext.define('EdiromOnline.controller.ConfigController', {
     config: null,
 
     init: function () {
-        console.log('ConfigController initialized');
     },
 
     /**
@@ -50,8 +49,6 @@ Ext.define('EdiromOnline.controller.ConfigController', {
         me.config = {
             backendURL: '@backend.url@'
         };
-
-        console.info('Fallback configuration applied:', me.config);
 
         if (callback) {
             Ext.callback(callback, scope || me, [me.config]);

--- a/app/controller/ConfigController.js
+++ b/app/controller/ConfigController.js
@@ -27,12 +27,12 @@ Ext.define('EdiromOnline.controller.ConfigController', {
                     }
                 } catch (e) {
                     console.error('Failed to parse config.json:', e.message);
-                    me.handleConfigError(callback, scope);
+                    me.loadDefaultConfig(callback, scope);
                 }
             },
             failure: function (response) {
                 console.info('No config.json provided: Using default value for backendURL.');
-                me.handleConfigError(callback, scope);
+                me.loadDefaultConfig(callback, scope);
             }
         });
     },
@@ -42,7 +42,7 @@ Ext.define('EdiromOnline.controller.ConfigController', {
      * @param {Function} callback Callback function
      * @param {Object} scope Scope for the callback
      */
-    handleConfigError: function (callback, scope) {
+    loadDefaultConfig: function (callback, scope) {
         var me = this;
 
         // Fallback-Konfiguration

--- a/app/controller/ConfigController.js
+++ b/app/controller/ConfigController.js
@@ -11,30 +11,29 @@ Ext.define('EdiromOnline.controller.ConfigController', {
      * @param {Function} callback Callback function after successful loading
      * @param {Object} scope Scope for the callback
      */
-    loadConfig: function (callback, scope) {
-        var me = this;
-
-        Ext.Ajax.request({
-            url: 'config.json',
-            method: 'GET',
-            success: function (response) {
-                try {
-                    me.config = JSON.parse(response.responseText);
-                    console.info('config.json for backendURL loaded.');
-
-                    if (callback) {
-                        Ext.callback(callback, scope || me, [me.config]);
-                    }
-                } catch (e) {
-                    console.error('Failed to parse config.json:', e.message);
-                    me.loadDefaultConfig(callback, scope);
+    async loadConfig(callback, scope) {
+        try {
+            const response = await fetch('config.json', {
+                method: 'GET',
+                headers: {
+                    'Content-Type': 'application/json'
                 }
-            },
-            failure: function (response) {
-                console.info('No config.json provided: Using default value for backendURL.');
-                me.loadDefaultConfig(callback, scope);
+            });
+
+            if (!response.ok) {
+                throw new Error(`Status: ${response.status}`);
             }
-        });
+
+            this.config = await response.json();
+            console.info('config.json for backendURL loaded.');
+
+            if (callback) {
+                callback.call(scope || this, this.config);
+            }
+        } catch (e) {
+            console.log('Could not load a custom config.json:', e.message, '– Using default configuration.');
+            this.loadDefaultConfig(callback, scope);
+        }
     },
 
     /**

--- a/app/controller/ConfigController.js
+++ b/app/controller/ConfigController.js
@@ -31,7 +31,7 @@ Ext.define('EdiromOnline.controller.ConfigController', {
                 callback.call(scope || this, this.config);
             }
         } catch (e) {
-            console.log('Could not load a custom config.json:', e.message, '– Using default configuration.');
+            console.log('No custom config.json found or syntax error – Using default configuration.');
             this.loadDefaultConfig(callback, scope);
         }
     },

--- a/app/controller/ConfigController.js
+++ b/app/controller/ConfigController.js
@@ -20,21 +20,19 @@ Ext.define('EdiromOnline.controller.ConfigController', {
             method: 'GET',
             success: function (response) {
                 try {
-                    if (response.responseText.startsWith('{')) {
-                        me.config = JSON.parse(response.responseText);
-                        console.log('Configuration loaded:', me.config);
-                    }                    
+                    me.config = JSON.parse(response.responseText);
+                    console.info('config.json for backendURL loaded.');
 
                     if (callback) {
                         Ext.callback(callback, scope || me, [me.config]);
                     }
                 } catch (e) {
-                    console.error('Error parsing config.json:', e);
+                    console.error('Failed to parse config.json:', e.message);
                     me.handleConfigError(callback, scope);
                 }
             },
             failure: function (response) {
-                console.warn('Could not load config.json:', response.status);
+                console.info('No config.json provided: Using default value for backendURL.');
                 me.handleConfigError(callback, scope);
             }
         });
@@ -53,7 +51,7 @@ Ext.define('EdiromOnline.controller.ConfigController', {
             backendURL: '@backend.url@'
         };
 
-        console.warn('Using fallback configuration:', me.config);
+        console.info('Fallback configuration applied:', me.config);
 
         if (callback) {
             Ext.callback(callback, scope || me, [me.config]);

--- a/app/controller/ConfigController.js
+++ b/app/controller/ConfigController.js
@@ -1,0 +1,129 @@
+Ext.define('EdiromOnline.controller.ConfigController', {
+    extend: 'Ext.app.Controller',
+
+    config: null,
+
+    init: function () {
+        console.log('ConfigController initialized');
+    },
+
+    /**
+     * Load config from config.json
+     * @param {Function} callback Callback function after successful loading
+     * @param {Object} scope Scope for the callback
+     */
+    loadConfig: function (callback, scope) {
+        var me = this;
+
+        Ext.Ajax.request({
+            url: 'config.json',
+            method: 'GET',
+            success: function (response) {
+                try {
+                    if (response.responseText.startsWith('{')) {
+                        me.config = JSON.parse(response.responseText);
+                        console.log('Configuration loaded:', me.config);
+                    }                    
+
+                    if (callback) {
+                        Ext.callback(callback, scope || me, [me.config]);
+                    }
+                } catch (e) {
+                    console.error('Error parsing config.json:', e);
+                    me.handleConfigError(callback, scope);
+                }
+            },
+            failure: function (response) {
+                console.warn('Could not load config.json:', response.status);
+                me.handleConfigError(callback, scope);
+            }
+        });
+    },
+
+    /**
+     * Handles errors when loading the configuration
+     * @param {Function} callback Callback function
+     * @param {Object} scope Scope for the callback
+     */
+    handleConfigError: function (callback, scope) {
+        var me = this;
+
+        // Fallback-Konfiguration
+        me.config = {
+            backendURL: '@backend.url@'
+        };
+
+        console.warn('Using fallback configuration:', me.config);
+
+        if (callback) {
+            Ext.callback(callback, scope || me, [me.config]);
+        }
+    },
+
+    /**
+     * Returns a configuration value
+     * @param {String} key The configuration key
+     * @param {*} defaultValue Default value if key doesn't exist
+     * @return {*} The configuration value
+     */
+    getConfig: function (key, defaultValue) {
+        if (!this.config) {
+            console.warn('Configuration not loaded yet');
+            return defaultValue;
+        }
+
+        return this.config[key] !== undefined ? this.config[key] : defaultValue;
+    },
+
+    /**
+     * Returns the complete configuration
+     * @return {Object} The configuration object
+     */
+    getFullConfig: function () {
+        return this.config || {};
+    },
+
+    /**
+     * Sets a configuration value
+     * @param {String|Object} key The configuration key or an object with key-value pairs
+     * @param {*} value The value to set (ignored if key is an object)
+     * @return {Boolean} True if the operation was successful
+     */
+    setConfig: function (key, value) {
+        var me = this;
+
+        // Initialize config if not already loaded
+        if (!me.config) {
+            me.config = {};
+        }
+
+        try {
+            if (Ext.isObject(key)) {
+                // If key is an object, merge it with existing config
+                me.config = Ext.apply(me.config, key);
+                console.log('Configuration updated with object:', key);
+            } else if (Ext.isString(key)) {
+                // Set single key-value pair
+                me.config[key] = value;
+                console.log('Configuration updated:', key, '=', value);
+            } else {
+                console.warn('Invalid key type for setConfig. Expected string or object.');
+                return false;
+            }
+
+            return true;
+        } catch (e) {
+            console.error('Error setting configuration:', e);
+            return false;
+        }
+    },
+
+    /**
+     * Checks if a configuration key exists
+     * @param {String} key The configuration key to check
+     * @return {Boolean} True if the key exists
+     */
+    hasConfig: function (key) {
+        return this.config && this.config.hasOwnProperty(key);
+    }
+});

--- a/app/controller/window/about/AboutWindow.js
+++ b/app/controller/window/about/AboutWindow.js
@@ -36,6 +36,9 @@ Ext.define('EdiromOnline.controller.window.about.AboutWindow', {
 
         var me = this;
 
+        var configController = me.getApplication().getController('ConfigController');
+        var backendURL = configController && configController.hasConfig('backendURL') ? configController.getConfig('backendURL') : '@backend.url@';
+
         if(view.initialized) return;
         view.initialized = true;
 
@@ -76,7 +79,7 @@ Ext.define('EdiromOnline.controller.window.about.AboutWindow', {
         // Fetching content of CITATION.cff files and set result
         Promise.all([
             fetchContent('../resources/CITATION.cff'),
-            fetchContent('@backend.url@resources/CITATION.cff')
+            fetchContent(`${backendURL}resources/CITATION.cff`)
         ]).then(function([frontend, backend]) {
             view.setResult(`
                 <div class="tei_body">

--- a/app/model/Annotation.js
+++ b/app/model/Annotation.js
@@ -40,5 +40,14 @@ Ext.define('EdiromOnline.model.Annotation', {
             root: 'annotations',
             totalProperty: 'total'
         }
+    },
+
+    statics: {
+        updateProxyUrl: function (backendURL) {
+            var model = Ext.ModelManager.getModel('EdiromOnline.model.Annotation');
+            if (model) {
+                model.getProxy().url = backendURL + 'data/xql/getAnnotations.xql';
+            }
+        }
     }
 });

--- a/app/model/Edition.js
+++ b/app/model/Edition.js
@@ -28,6 +28,15 @@ Ext.define('EdiromOnline.model.Edition', {
         url: '@backend.url@data/xql/getEdition.xql'
     },
 
+    statics: {
+        updateProxyUrl: function (backendURL) {
+            var model = Ext.ModelManager.getModel('EdiromOnline.model.Edition');
+            if (model) {
+                model.getProxy().url = backendURL + 'data/xql/getEdition.xql';
+            }
+        }
+    },
+
     /**
      * Concordances
      */

--- a/app/model/Work.js
+++ b/app/model/Work.js
@@ -28,5 +28,14 @@ Ext.define('EdiromOnline.model.Work', {
     proxy: {
         type: 'ajax',
         url: '@backend.url@data/xql/getWorks.xql'
-    }
+    },
+
+    statics: {
+        updateProxyUrl: function (backendURL) {
+            var model = Ext.ModelManager.getModel('EdiromOnline.model.Work');
+            if (model) {
+                model.getProxy().url = backendURL + 'data/xql/getWorks.xql';
+            }
+        }
+    },
 });

--- a/app/view/window/image/VerovioImage.js
+++ b/app/view/window/image/VerovioImage.js
@@ -34,6 +34,9 @@ Ext.define('EdiromOnline.view.window.image.VerovioImage', {
 	setIFrameContent: function (uri, edition) {
 		var me = this;
 
+		var configController = me.getApplication().getController('ConfigController');
+		var backendURL = configController && configController.hasConfig('backendURL') ? configController.getConfig('backendURL') : '@backend.url@';
+
 		var html = `<html>
         		<head>
 					<title>Verovio</title>
@@ -94,7 +97,7 @@ Ext.define('EdiromOnline.view.window.image.VerovioImage', {
 						var uri = "${uri}";
 						var edition = "${edition}";
 						var movementId = "";
-						var appBasePath = "@backend.url@";
+						var appBasePath = "${backendURL}";
 					</script>
 					<script
 						src="resources/js/verovio-view.js"></script>

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -29,6 +29,7 @@ Ext.Loader.addClassPathMappings({
 Ext.ClassManager.addNameAlternateMappings({
   "EdiromOnline.Application": [],
   "EdiromOnline.controller.AJAXController": [],
+  "EdiromOnline.controller.ConfigController": [],
   "EdiromOnline.controller.CookieController": [],
   "EdiromOnline.controller.LanguageController": [],
   "EdiromOnline.controller.LinkController": [],
@@ -942,6 +943,7 @@ Ext.ClassManager.addNameAlternateMappings({
 Ext.ClassManager.addNameAliasMappings({
   "EdiromOnline.Application": [],
   "EdiromOnline.controller.AJAXController": [],
+  "EdiromOnline.controller.ConfigController": [],
   "EdiromOnline.controller.CookieController": [],
   "EdiromOnline.controller.LanguageController": [],
   "EdiromOnline.controller.LinkController": [],


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Currently, the backend URL is written from the build.xml at build time. This makes it difficult to change the backend endpoint without rebuilding the application.

**Describe the solution you'd like**
Enable passing the backend URL at runtime by placing a `config.json` file in the root directory of the built app. The file should use the following format:

```json
{
  "backendURL": "http://127.0.0.1:8081/"
}
```
If present, the app should use the URL from config.json instead of the build-time value.

This relates to Issue: #16.

**Additional context**
- Built app tested with and without config.json
- After adding config.json to the running nginx container serving the frontend, a reload reflects the new request URL in browser dev-tools.
- Inline documentation updated accordingly.
- Self-reviewed code per [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- Read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document
- Added tests to [testing](https://github.com/Edirom/Edirom-Online-Frontend/tree/develop/testing)
- All new and existing tests passed.